### PR TITLE
Memorize GenerationID

### DIFF
--- a/watches.go
+++ b/watches.go
@@ -70,6 +70,7 @@ func (wm *watchManager) manageWatch(conn *websocket.Conn, topic, genID string, i
 				handleError(err, conn)
 				return
 			}
+			genID = msgsResponse.GenerationID
 			idx = msgsResponse.Messages[msgsLength-1].Index + 1
 		}
 		time.Sleep(wm.pushInterval)


### PR DESCRIPTION
Currently if at the time of the request, the provided genID is different then the current genID, every pushInterval (5 sec default) all messages are replied. Updated description.

[1] that would happen when prometheus-alert-buffer goes down & up and a client attempts to reconnect based on last known generation & index.